### PR TITLE
Autocompile

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
+## Python Version
+
+Currently, the only python version suppoted and testsed for is `python 2.7`.
+
 ## Types supported to Import and Export
 
 - String
@@ -211,4 +215,4 @@ then everything is working as should.
 
 ### Pointing to the right python
 
-By default, matpy will build with the systems default python. If you want it to reference a specific python, you'll need to make a file `~/.matpyrc` and set the python you want matlab to use (and only that string), for example I have `/.pyenv/versions/2.7.9/bin/python` as the only line in my `~/.matpyrc` file.
+By default, matpy will build with the systems default python. If you want it to reference a specific python, you'll need to make a file `~/.matpyrc` and set the python you want matlab to use (and only that string), for example I have `/Users/samuelmassinon/.pyenv/versions/2.7.9/bin/python` as the only line in my `~/.matpyrc` file.

--- a/README.md
+++ b/README.md
@@ -208,3 +208,7 @@ If your last line after compiling is,
 7 warnings generated.
 ```
 then everything is working as should.
+
+### Pointing to the right python
+
+By default, matpy will build with the systems default python. If you want it to reference a specific python, you'll need to make a file `~/.matpyrc` and set the python you want matlab to use (and only that string), for example I have `/.pyenv/versions/2.7.9/bin/python` as the only line in my `~/.matpyrc` file.

--- a/py.m
+++ b/py.m
@@ -1,18 +1,19 @@
 % A way to interact with python from matlab.
-% 
+%
 % Inputs:
 % 	1) the type of command, which can be any of the following:
 % 		a. 'eval' this will run the second parameter as python
-% 		b. 'set'  this will export the second parameter to python
+% 		b. 'set'  this will export the third value by name of second parameter to python
 % 		c. 'get'  this will import the second parameter from python by name
 % 		d. 'debugon'  used for debugging
 % 		c. 'debugoff' used for debugging (default is this)
-% 	2) this parameter will interact with python depending on what is passed in 
+% 	2) this parameter will interact with python depending on what is passed in
 % 		the first parameter, see above for what that would be
-% 
+%	3) only for 'set' command, see above
+%
 % Output:
 % 	only for 'get' command, will return the value stored in python
-% 
+%
 % Examples:
 % 	py('eval', 'print "hello, world"')
 %	py('eval', 'print 2+2')
@@ -20,74 +21,77 @@
 %	var = py('get' 'name_of_var')
 
 function varargout = py(varargin)
-	
+
 	lastWorkingDir = pwd;
 	cd(mfiledir);
 
-	home = getenv('HOME');
-	partialPath = getParsedPypath();
-	parent ='/..';
+	[execPrefix pythonVersion] = getParsedPypath();
 
-	CHAR16_T = '-Dchar16_t=uint16_T';
-
-	pre = '-I';
-	includePath = '/include/python2.7';
-	PYINCLUDEDIR = strcat(pre, home, partialPath, parent, includePath)
-
-	pre = '-L';
-	libraryPath = '/lib/python2.7';
-	PYLIBPATH = strcat(pre, home, partialPath, parent, libraryPath)
-
-	pre = '''-DPYPATH=\"';
-	pythonPath = '/python';
-	post = '\"''';
-	PYPATH = strcat(pre, home, partialPath, pythonPath, post);
-
-	SPACE = ' ';
-	CFLAG = 'CFLAGS="\$CFLAGS';
-	PYNAME = '-lpython2.7';
-	END_QUOTATION = '"';
-	PRE = [CFLAG, SPACE, PYNAME, SPACE, PYPATH, END_QUOTATION];
+	PYINCLUDEDIR = ['-I', getPyIncludePath(execPrefix, pythonVersion)];
+	PYLIBPATH = ['-L', execPrefix, '/../lib/python', pythonVersion];
+	PYPATH = ['''-DPYPATH=\"', execPrefix, '/python', '\"'''];
+	CFLAGS = ['CFLAGS="\$CFLAGS ', ' -lpython2.7 ', PYPATH, '"'];
 
 	try
-		mex('py.cpp', PRE, CHAR16_T, PYINCLUDEDIR, PYLIBPATH);
+		mex('py.cpp', CFLAGS, '-Dchar16_t=uint16_T', PYINCLUDEDIR, PYLIBPATH);
 	catch e
 		cd(lastWorkingDir);
 		rethrow(e);
 	end
 
 	cd(lastWorkingDir);
-	
+
 	[varargout{1:nargout}] = py(varargin{:});
 end
 
-function partialPath = getParsedPypath()
-	temp = getPypath();
-	tokens = splitBySlash(temp);
-	partialPath = cutOffEndsAndMerge(tokens);
+function [execPrefix, pythonVersion] = getParsedPypath()
+	executable = getPypath();
+	pythonVersion = getPythonVersion(executable);
+	tokens = splitBySlash(executable);
+	execPrefix = ['/', fullfile(tokens{1:end-1})];
 end
 
-function partialPath = getPypath()
+function tokens = splitBySlash(str)
+	tokens = strread(str, '%s', 'delimiter', '/');
+end
+
+function executable = getPypath()
 
 	SUCCESS = 0;
-	[success, partialPath] = system('cat ~/.matpyrc');
+	[success, executable] = system('cat ~/.matpyrc');
 
 	if success ~= SUCCESS
 		%Failed to find custom python, using systems
 
-		[success, partialPath] = system('which python');
+		[success, executable] = system('which python');
 
 		if success ~= SUCCESS
 			error('Python could not be found');
 		end
 	end
 
+	executable = strtrim(executable);
+
 end
 
-function tokens = splitBySlash(str)
-	tokens = strread(str, '%s', 'delimiter', '/')
+function pythonVersion = getPythonVersion(executable)
+	SUCCESS = 0;
+	[success pythonVersion] = system([executable, ' -c "import platform; print(platform.python_version()[:3])"']);
+
+	if success ~= SUCCESS
+		error('Could not get version number of python');
+	end
+	pythonVersion = strtrim(pythonVersion);
 end
 
-function partialPath = cutOffEndsAndMerge(tokens)
-	partialPath = sprintf('/%s' ,tokens{2:end-1})
+function pyIncludePath = getPyIncludePath(execPrefix, pythonVersion)
+	pyIncludePath = [execPrefix, '/../include/python', pythonVersion];
+
+	FOLDER_FOUND = 7;
+	result = exist(pyIncludePath);
+
+	if(result ~= FOLDER_FOUND)
+		% there's a chance that the python include path has an m on the end of it
+		pyIncludePath = [pyIncludePath, 'm'];
+	end
 end

--- a/py.m
+++ b/py.m
@@ -1,0 +1,95 @@
+% Converts string to double precision value. The string may contain digits,
+% commas (thousands separator), a decimal point, a leading + or - sign,
+% an 'e' preceding a power of 10 scale factor, and an 'i' for a complex 
+% unit. 
+% 
+
+
+% 
+% A way to interact with python from matlab.
+% 
+% Inputs:
+% 	1) the type of command, which can be any of the following:
+% 		a. 'eval' this will run the second parameter as python
+% 		b. 'set'  this will export the second parameter to python
+% 		c. 'get'  this will import the second parameter from python by name
+% 		d. 'debugon'  used for debugging
+% 		c. 'debugoff' used for debugging (default is this)
+% 	2) this parameter will interact with python depending on what is passed in 
+% 		the first parameter, see above for what that would be
+% 
+% Output:
+% 	only for 'get' command, will return the value stored in python
+% 
+% Examples:
+% 	tmp = py('eval', 'print "hi"')
+% 
+
+
+%
+% If the string does not represent a valid scalar value a NaN is
+% returned instead.
+%
+% Inputs:
+%   Char or Cellstr, converts the strings into double precision values. If
+%     a cell is given a matrix will be returned of the same dimensions. NaN
+%     values will be returned for non-parsable strings.
+%
+% Outputs:
+%   Double Matrix, a scalar double if a char was given or a matrix of the s
+%     size of the given cellstr.
+%
+% Examples:
+%   str2double( '123.45e7' )
+%   str2double( '123 + 45i' )
+%   str2double( '3.14159' )
+%   str2double( '2.7i - 3.14' )
+%   str2double( { '2.71' '3.1415' } )
+%   str2double( '1,200.34' )
+%
+% See also: str2num, num2str, hex2num, char.
+
+% 25 August 2011
+% Curtis Vogt
+% Added comments and automatic compiling to help function.
+
+function varargout = py(varargin)
+	lastWorkingDir = pwd;
+	cd(mfiledir);
+
+	home = getenv('HOME');
+	SPACE = ' '
+
+	CHAR16_t = '-Dchar16_t=uint16_T';
+
+	PYNAME = '-lpython2.7';
+
+	pre = '-I';
+	partialPath = '/.pyenv/versions/2.7.9/include/python2.7';
+	PYINCLUDEDIR = strcat(pre, home, partialPath);
+
+	pre = '-L';
+	partialPath = '/.pyenv/versions/2.7.9/lib/python2.7';
+	PYLIBPATH = strcat(pre, home, partialPath);
+
+	pre = '''-DPYPATH=\"';
+	post = '\"''';
+	partialPath = '/.pyenv/versions/2.7.9/bin/python';
+	PYPATH = strcat(pre, home, partialPath, post);
+
+	% I could not include PYNAME here without the compiler throwing a strange error.
+	MODIFIERS = [CHAR16_t, SPACE, PYPATH, SPACE, PYINCLUDEDIR, SPACE, PYLIBPATH];
+
+	try
+		% I could not place PYPATH here without compining it with other strings 
+		% without the compiler ignoring it
+		mex('py.cpp', PYNAME, MODIFIERS);
+	catch e
+		cd(lastWorkingDir);
+		rethrow(e);
+	end
+
+	cd(lastWorkingDir);
+	
+	[varargout{1:nargout}] = py(varargin{:});
+end

--- a/py.m
+++ b/py.m
@@ -87,10 +87,9 @@ end
 function pyIncludePath = getPyIncludePath(execPrefix, pythonVersion)
 	pyIncludePath = [execPrefix, '/../include/python', pythonVersion];
 
-	FOLDER_FOUND = 7;
 	result = exist(pyIncludePath, 'dir');
 
-	if(result ~= FOLDER_FOUND)
+	if(~result)
 		% there's a chance that the python include path has an m on the end of it
 		pyIncludePath = [pyIncludePath, 'm'];
 	end

--- a/py.m
+++ b/py.m
@@ -1,11 +1,3 @@
-% Converts string to double precision value. The string may contain digits,
-% commas (thousands separator), a decimal point, a leading + or - sign,
-% an 'e' preceding a power of 10 scale factor, and an 'i' for a complex 
-% unit. 
-% 
-
-
-% 
 % A way to interact with python from matlab.
 % 
 % Inputs:
@@ -22,36 +14,10 @@
 % 	only for 'get' command, will return the value stored in python
 % 
 % Examples:
-% 	tmp = py('eval', 'print "hi"')
-% 
-
-
-%
-% If the string does not represent a valid scalar value a NaN is
-% returned instead.
-%
-% Inputs:
-%   Char or Cellstr, converts the strings into double precision values. If
-%     a cell is given a matrix will be returned of the same dimensions. NaN
-%     values will be returned for non-parsable strings.
-%
-% Outputs:
-%   Double Matrix, a scalar double if a char was given or a matrix of the s
-%     size of the given cellstr.
-%
-% Examples:
-%   str2double( '123.45e7' )
-%   str2double( '123 + 45i' )
-%   str2double( '3.14159' )
-%   str2double( '2.7i - 3.14' )
-%   str2double( { '2.71' '3.1415' } )
-%   str2double( '1,200.34' )
-%
-% See also: str2num, num2str, hex2num, char.
-
-% 25 August 2011
-% Curtis Vogt
-% Added comments and automatic compiling to help function.
+% 	py('eval', 'print "hello, world"')
+%	py('eval', 'print 2+2')
+%	py('set', 'name_of_var', var)
+%	var = py('get' 'name_of_var')
 
 function varargout = py(varargin)
 	lastWorkingDir = pwd;

--- a/py.m
+++ b/py.m
@@ -88,7 +88,7 @@ function pyIncludePath = getPyIncludePath(execPrefix, pythonVersion)
 	pyIncludePath = [execPrefix, '/../include/python', pythonVersion];
 
 	FOLDER_FOUND = 7;
-	result = exist(pyIncludePath);
+	result = exist(pyIncludePath, 'dir');
 
 	if(result ~= FOLDER_FOUND)
 		% there's a chance that the python include path has an m on the end of it


### PR DESCRIPTION
This was the best way I could find to include the python path in the build, if there's a better way that allows us to not have hard coded string in the file and for it not to force everything to have everything in `~/.pyenv/versions/2.7.9/` please let me know.
